### PR TITLE
Allow user to set ffmpeg path via environment variable

### DIFF
--- a/faceless/ffmpeg.py
+++ b/faceless/ffmpeg.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+import os
 import subprocess
 
 from .vision import pack_resolution, restrict_video_fps
@@ -7,8 +8,11 @@ from .vision import pack_resolution, restrict_video_fps
 from .typing import Fps, FrameFormat, OutputVideoEncoder, OutputVideoPreset, Resolution
 from .filesystem import get_temp_frames_pattern
 
+
 def run_ffmpeg(args : List[str]):
-    commands = [ 'ffmpeg', '-hide_banner', '-loglevel', 'error' ]
+
+    ffmpeg_path = os.environ.get("COMFYUI_FACELESS_FFMPEG") or "/usr/bin/ffmpeg"
+    commands = [ ffmpeg_path, '-hide_banner', '-loglevel', 'error' ]
     commands.extend(args)
     process = subprocess.Popen(commands, stderr = subprocess.PIPE, stdout = subprocess.PIPE)
     code = process.wait(timeout = 300)


### PR DESCRIPTION
Hi! I just ran into an issue on macOS, running this with a Homebrew installed version of ffmpeg. The function as-is assumes that the shell is aware of the location of ffmpeg via $PATH, but depending on how you execute the node, your path may be wiped out. I've seen other nodes use this sort of method as a workaround to that.